### PR TITLE
chore: add offline build script for expo app

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build": "EXPO_OFFLINE=1 expo export"
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.5.20",


### PR DESCRIPTION
## Summary
- add Expo export build script

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5263c9f0c832a9ee2c18eca5c2277