### PR TITLE
Use SafeAreaView to avoid system button overlap

### DIFF
--- a/src/screens/CardsScreen.js
+++ b/src/screens/CardsScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, Button, StyleSheet, Pressable, Switch, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { getQuestionsByQuiz, applySrsResult } from '../db';
 import TagChips from '../components/TagChips';
 import { distinctTagsFromQuestions, tagCounts, parseTags } from '../util/tags';
@@ -41,10 +42,12 @@ export default function CardsScreen({ route, navigation }) {
   }, [all, selected, onlyDue]);
 
   if (cards.length === 0) return (
-    <View style={styles.container}>
-      <Controls tags={tags} counts={counts} selected={selected} onToggle={toggleTag(setSelected)} onlyDue={onlyDue} setOnlyDue={setOnlyDue} />
-      <Text>Sem cartões para este filtro.</Text>
-    </View>
+    <SafeAreaView style={styles.sa} edges={['top','bottom']}>
+      <View style={styles.container}>
+        <Controls tags={tags} counts={counts} selected={selected} onToggle={toggleTag(setSelected)} onlyDue={onlyDue} setOnlyDue={setOnlyDue} />
+        <Text>Sem cartões para este filtro.</Text>
+      </View>
+    </SafeAreaView>
   );
 
   const cur = cards[idx];
@@ -57,26 +60,28 @@ export default function CardsScreen({ route, navigation }) {
   };
 
   return (
-    <View style={styles.container}>
-      <Controls tags={tags} counts={counts} selected={selected} onToggle={toggleTag(setSelected)} onlyDue={onlyDue} setOnlyDue={setOnlyDue} />
+    <SafeAreaView style={styles.sa} edges={['top','bottom']}>
+      <View style={styles.container}>
+        <Controls tags={tags} counts={counts} selected={selected} onToggle={toggleTag(setSelected)} onlyDue={onlyDue} setOnlyDue={setOnlyDue} />
 
-      <Pressable onPress={() => setShow(!show)} style={styles.card}>
-        <Text style={styles.term}>{!show ? cur.text : cur.answer}</Text>
-        <Text style={styles.hint}>{!show ? 'Toque para ver a resposta' : 'Toque para ocultar'}</Text>
-      </Pressable>
+        <Pressable onPress={() => setShow(!show)} style={styles.card}>
+          <Text style={styles.term}>{!show ? cur.text : cur.answer}</Text>
+          <Text style={styles.hint}>{!show ? 'Toque para ver a resposta' : 'Toque para ocultar'}</Text>
+        </Pressable>
 
-      {show ? (
-        <View style={styles.row}>
-          <View style={{ flex: 1 }}><Button title="Errei" onPress={async () => { setScore(s => ({ ...s, wrong: s.wrong + 1 })); await applySrsResult(cur.id, false); next(); }} /></View>
-          <View style={{ width: 8 }} />
-          <View style={{ flex: 1 }}><Button title="Acertei" onPress={async () => { setScore(s => ({ ...s, right: s.right + 1 })); await applySrsResult(cur.id, true); next(); }} /></View>
-        </View>
-      ) : (
-        <Button title="Mostrar resposta" onPress={() => setShow(true)} />
-      )}
+        {show ? (
+          <View style={styles.row}>
+            <View style={{ flex: 1 }}><Button title="Errei" onPress={async () => { setScore(s => ({ ...s, wrong: s.wrong + 1 })); await applySrsResult(cur.id, false); next(); }} /></View>
+            <View style={{ width: 8 }} />
+            <View style={{ flex: 1 }}><Button title="Acertei" onPress={async () => { setScore(s => ({ ...s, right: s.right + 1 })); await applySrsResult(cur.id, true); next(); }} /></View>
+          </View>
+        ) : (
+          <Button title="Mostrar resposta" onPress={() => setShow(true)} />
+        )}
 
-      <Text style={{ marginTop: 12, color: '#555' }}>{idx + 1} / {cards.length} • Acertos: {score.right}</Text>
-    </View>
+        <Text style={{ marginTop: 12, color: '#555' }}>{idx + 1} / {cards.length} • Acertos: {score.right}</Text>
+      </View>
+    </SafeAreaView>
   );
 }
 
@@ -106,6 +111,7 @@ function toggleTag(setSelected) {
 function shuffle(arr) { return [...arr].sort(() => Math.random() - 0.5); }
 
 const styles = StyleSheet.create({
+  sa: { flex: 1, backgroundColor: '#f7f7f7' },
   container: { flex: 1, padding: 16 },
   panel: { padding: 12, backgroundColor: '#fff', borderRadius: 12, borderWidth: 1, borderColor: '#eee', marginBottom: 12 },
   switchRow: { flexDirection: 'row', alignItems: 'center', marginTop: 8 },

--- a/src/screens/ImportScreen.js
+++ b/src/screens/ImportScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import { importText } from '../util/importer';
@@ -32,16 +33,21 @@ export default function ImportScreen({ navigation }) {
   };
 
   return (
-    <View style={styles.container}>
-      <Text>Selecione um arquivo CSV ou JSON com perguntas e respostas.</Text>
-      <View style={{ height: 12 }} />
-      <Button title="Escolher arquivo" onPress={pick} />
-      <View style={{ height: 16 }} />
-      {loading ? <ActivityIndicator /> : <Text style={{ color: '#555' }}>{status}</Text>}
-      <View style={{ height: 12 }} />
-      <Text style={{ color: '#777' }}>CSV: quiz,pergunta,resposta,explicacao,tags</Text>
-    </View>
+    <SafeAreaView style={styles.sa} edges={['top','bottom']}>
+      <View style={styles.container}>
+        <Text>Selecione um arquivo CSV ou JSON com perguntas e respostas.</Text>
+        <View style={{ height: 12 }} />
+        <Button title="Escolher arquivo" onPress={pick} />
+        <View style={{ height: 16 }} />
+        {loading ? <ActivityIndicator /> : <Text style={{ color: '#555' }}>{status}</Text>}
+        <View style={{ height: 12 }} />
+        <Text style={{ color: '#777' }}>CSV: quiz,pergunta,resposta,explicacao,tags</Text>
+      </View>
+    </SafeAreaView>
   );
 }
 
-const styles = StyleSheet.create({ container: { flex: 1, padding: 16 } });
+const styles = StyleSheet.create({
+  sa: { flex: 1, backgroundColor: '#f7f7f7' },
+  container: { flex: 1, padding: 16 }
+});

--- a/src/screens/LearnScreen.js
+++ b/src/screens/LearnScreen.js
@@ -1,6 +1,7 @@
 // src/screens/LearnScreen.js
 import React, { useEffect, useState } from 'react';
 import { View, Text, Button, StyleSheet, Switch, Pressable } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { getQuestionsByQuiz, getQuizzes, applySrsResult } from '../db';
 import TagChips from '../components/TagChips';
 import { distinctTagsFromQuestions, tagCounts, parseTags } from '../util/tags';
@@ -80,6 +81,40 @@ export default function LearnScreen({ route, navigation }) {
 
   if (!state.current) {
     return (
+      <SafeAreaView style={styles.sa} edges={['top','bottom']}>
+        <View style={styles.container}>
+          <View style={styles.panel}>
+            <TagChips tags={tags} counts={counts} selected={selected} onToggle={toggleTag(setSelected)} />
+            <View style={styles.switchRow}>
+              <Text>Somente vencidas (SRS)</Text>
+              <Switch value={onlyDueState} onValueChange={setOnlyDue} />
+            </View>
+          </View>
+          <Text style={{ color: '#666' }}>Sem questões para este filtro.</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (state.finished) {
+    return (
+      <SafeAreaView style={styles.sa} edges={['top','bottom']}>
+        <View style={styles.container}>
+          <View style={styles.panel}>
+            <Text style={styles.title}>Sessão concluída</Text>
+            <Text>Pontuação: {state.score}/{state.total}</Text>
+            <View style={{ height: 12 }} />
+            <Button title="Concluir" onPress={() => navigation.goBack()} />
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const progress = state.total ? (state.index + 1) / state.total : 0;
+
+  return (
+    <SafeAreaView style={styles.sa} edges={['top','bottom']}>
       <View style={styles.container}>
         <View style={styles.panel}>
           <TagChips tags={tags} counts={counts} selected={selected} onToggle={toggleTag(setSelected)} />
@@ -88,63 +123,35 @@ export default function LearnScreen({ route, navigation }) {
             <Switch value={onlyDueState} onValueChange={setOnlyDue} />
           </View>
         </View>
-        <Text style={{ color: '#666' }}>Sem questões para este filtro.</Text>
-      </View>
-    );
-  }
 
-  if (state.finished) {
-    return (
-      <View style={styles.container}>
         <View style={styles.panel}>
-          <Text style={styles.title}>Sessão concluída</Text>
-          <Text>Pontuação: {state.score}/{state.total}</Text>
-          <View style={{ height: 12 }} />
-          <Button title="Concluir" onPress={() => navigation.goBack()} />
-        </View>
-      </View>
-    );
-  }
-
-  const progress = state.total ? (state.index + 1) / state.total : 0;
-
-  return (
-    <View style={styles.container}>
-      <View style={styles.panel}>
-        <TagChips tags={tags} counts={counts} selected={selected} onToggle={toggleTag(setSelected)} />
-        <View style={styles.switchRow}>
-          <Text>Somente vencidas (SRS)</Text>
-          <Switch value={onlyDueState} onValueChange={setOnlyDue} />
-        </View>
-      </View>
-
-      <View style={styles.panel}>
-        <View style={styles.progressOuter}>
-          <View style={[styles.progressInner, { width: `${Math.round(progress * 100)}%` }]} />
-        </View>
-        <Text style={styles.title}>{state.current.text}</Text>
-
-        {!state.answered ? (
-          state.options.map((opt, idx) => (
-            <Pressable key={idx} onPress={() => onAnswer(idx)} style={({ pressed }) => [styles.option, pressed && { opacity: 0.8 }]}>
-              <Text style={{ flexWrap: 'wrap' }}>{String(opt)}</Text>
-            </Pressable>
-          ))
-        ) : (
-          <View>
-            <Text style={{ fontWeight: '700', color: state.answered.isCorrect ? '#2e7d32' : '#b00020' }}>
-              {state.answered.isCorrect ? 'Correto!' : 'Incorreto.'}
-            </Text>
-            {!state.answered.isCorrect ? <Text style={{ marginTop: 6, flexWrap: 'wrap' }}>Sua resposta: {String(state.answered.chosen)}</Text> : null}
-            <Text style={{ marginTop: 6, flexWrap: 'wrap' }}>Resposta correta: {String(state.current.answer)}</Text>
-            {state.current.explanation ? <Text style={{ marginTop: 6, color: '#333', flexWrap: 'wrap' }}>Explicação: {state.current.explanation}</Text> : null}
-            <View style={{ height: 12 }} />
-            <Button title="Próxima" onPress={next} />
+          <View style={styles.progressOuter}>
+            <View style={[styles.progressInner, { width: `${Math.round(progress * 100)}%` }]} />
           </View>
-        )}
-        <Text style={{ marginTop: 10, color: '#555' }}>{state.index + 1} de {state.total}</Text>
+          <Text style={styles.title}>{state.current.text}</Text>
+
+          {!state.answered ? (
+            state.options.map((opt, idx) => (
+              <Pressable key={idx} onPress={() => onAnswer(idx)} style={({ pressed }) => [styles.option, pressed && { opacity: 0.8 }]}>
+                <Text style={{ flexWrap: 'wrap' }}>{String(opt)}</Text>
+              </Pressable>
+            ))
+          ) : (
+            <View>
+              <Text style={{ fontWeight: '700', color: state.answered.isCorrect ? '#2e7d32' : '#b00020' }}>
+                {state.answered.isCorrect ? 'Correto!' : 'Incorreto.'}
+              </Text>
+              {!state.answered.isCorrect ? <Text style={{ marginTop: 6, flexWrap: 'wrap' }}>Sua resposta: {String(state.answered.chosen)}</Text> : null}
+              <Text style={{ marginTop: 6, flexWrap: 'wrap' }}>Resposta correta: {String(state.current.answer)}</Text>
+              {state.current.explanation ? <Text style={{ marginTop: 6, color: '#333', flexWrap: 'wrap' }}>Explicação: {state.current.explanation}</Text> : null}
+              <View style={{ height: 12 }} />
+              <Button title="Próxima" onPress={next} />
+            </View>
+          )}
+          <Text style={{ marginTop: 10, color: '#555' }}>{state.index + 1} de {state.total}</Text>
+        </View>
       </View>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -206,6 +213,7 @@ function sample(arr, n) {
 function shuffle(arr) { return [...arr].sort(() => Math.random() - 0.5); }
 
 const styles = StyleSheet.create({
+  sa: { flex: 1, backgroundColor: '#f7f7f7' },
   container: { flex: 1, padding: 16 },
   panel: { padding: 12, backgroundColor: '#fff', borderRadius: 12, borderWidth: 1, borderColor: '#eee', marginBottom: 12 },
   switchRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },

--- a/src/screens/QuestionEditorScreen.js
+++ b/src/screens/QuestionEditorScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { createQuestion } from '../db';
 
 export default function QuestionEditorScreen({ route, navigation }) {
@@ -15,21 +16,24 @@ export default function QuestionEditorScreen({ route, navigation }) {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.label}>Pergunta (termo)</Text>
-      <TextInput style={[styles.input, { height: 100 }]} multiline value={text} onChangeText={setText} />
-      <Text style={styles.label}>Resposta (definição)</Text>
-      <TextInput style={styles.input} value={answer} onChangeText={setAnswer} />
-      <Text style={styles.label}>Explicação (opcional)</Text>
-      <TextInput style={styles.input} value={explanation} onChangeText={setExplanation} />
-      <Text style={styles.label}>Tags (opcional)</Text>
-      <TextInput style={styles.input} value={tags} onChangeText={setTags} />
-      <Button title="Salvar" onPress={save} disabled={!text.trim() || !answer.trim()} />
-    </View>
+    <SafeAreaView style={styles.sa} edges={['top','bottom']}>
+      <View style={styles.container}>
+        <Text style={styles.label}>Pergunta (termo)</Text>
+        <TextInput style={[styles.input, { height: 100 }]} multiline value={text} onChangeText={setText} />
+        <Text style={styles.label}>Resposta (definição)</Text>
+        <TextInput style={styles.input} value={answer} onChangeText={setAnswer} />
+        <Text style={styles.label}>Explicação (opcional)</Text>
+        <TextInput style={styles.input} value={explanation} onChangeText={setExplanation} />
+        <Text style={styles.label}>Tags (opcional)</Text>
+        <TextInput style={styles.input} value={tags} onChangeText={setTags} />
+        <Button title="Salvar" onPress={save} disabled={!text.trim() || !answer.trim()} />
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  sa: { flex: 1, backgroundColor: '#f7f7f7' },
   container: { flex: 1, padding: 16, gap: 8 },
   label: { fontWeight: '600' },
   input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 10 }

--- a/src/screens/QuizEditorScreen.js
+++ b/src/screens/QuizEditorScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { createQuiz } from '../db';
 
 export default function QuizEditorScreen({ navigation }) {
@@ -9,17 +10,20 @@ export default function QuizEditorScreen({ navigation }) {
   const save = async () => { await createQuiz(title, desc); navigation.goBack(); };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.label}>Título</Text>
-      <TextInput style={styles.input} value={title} onChangeText={setTitle} />
-      <Text style={styles.label}>Descrição (opcional)</Text>
-      <TextInput style={[styles.input, { height: 100 }]} multiline value={desc} onChangeText={setDesc} />
-      <Button title="Salvar" onPress={save} disabled={!title.trim()} />
-    </View>
+    <SafeAreaView style={styles.sa} edges={['top','bottom']}>
+      <View style={styles.container}>
+        <Text style={styles.label}>Título</Text>
+        <TextInput style={styles.input} value={title} onChangeText={setTitle} />
+        <Text style={styles.label}>Descrição (opcional)</Text>
+        <TextInput style={[styles.input, { height: 100 }]} multiline value={desc} onChangeText={setDesc} />
+        <Button title="Salvar" onPress={save} disabled={!title.trim()} />
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  sa: { flex: 1, backgroundColor: '#f7f7f7' },
   container: { flex: 1, padding: 16, gap: 8 },
   label: { fontWeight: '600' },
   input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 10 }


### PR DESCRIPTION
## Summary
- wrap editor, import, cards, and learning screens in SafeAreaView to respect top and bottom insets
- add light background style for new SafeAreaView containers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a531745ddc832abf547f5dfc7b272d