### PR TITLE
feat: revamp interface with theme and styled buttons

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,9 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { StatusBar } from 'expo-status-bar';
+
+import { navTheme } from './src/theme';
 
 import HomeScreen from './src/screens/HomeScreen';
 import QuizEditorScreen from './src/screens/QuizEditorScreen';
@@ -22,7 +25,20 @@ const Tab = createBottomTabNavigator();
 
 function Tabs() {
   return (
-    <Tab.Navigator screenOptions={{ headerShown: false }}>
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: navTheme.colors.primary,
+        tabBarInactiveTintColor: '#666',
+        tabBarStyle: {
+          backgroundColor: '#fff',
+          borderTopColor: '#eee',
+          height: 56,
+          paddingTop: 6,
+          paddingBottom: 6
+        }
+      }}
+    >
       <Tab.Screen
         name="Início"
         component={HomeScreen}
@@ -50,8 +66,14 @@ function Tabs() {
 export default function App() {
   useEffect(() => { initDb(); }, []);
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
+    <NavigationContainer theme={navTheme}>
+      <StatusBar style="light" backgroundColor={navTheme.colors.primary} />
+      <Stack.Navigator
+        screenOptions={{
+          headerStyle: { backgroundColor: navTheme.colors.primary },
+          headerTintColor: '#fff'
+        }}
+      >
         <Stack.Screen name="Tabs" component={Tabs} options={{ headerShown: false }} />
         <Stack.Screen name="QuizEditor" component={QuizEditorScreen} options={{ title: 'Novo Quiz' }} />
         <Stack.Screen name="QuestionList" component={QuestionListScreen} options={{ title: 'Perguntas' }} />

--- a/src/components/PrimaryButton.js
+++ b/src/components/PrimaryButton.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet } from 'react-native';
+import { navTheme } from '../theme';
+
+export default function PrimaryButton({ title, onPress, disabled, style }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.button,
+        style,
+        disabled && styles.disabled,
+        pressed && !disabled && styles.pressed
+      ]}
+    >
+      <Text style={styles.text}>{title}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: navTheme.colors.primary,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    alignItems: 'center'
+  },
+  text: { color: '#fff', fontWeight: '600' },
+  pressed: { opacity: 0.85 },
+  disabled: { backgroundColor: '#aaa' }
+});

--- a/src/screens/BackupScreen.js
+++ b/src/screens/BackupScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import * as DocumentPicker from 'expo-document-picker';
@@ -89,9 +90,9 @@ export default function BackupScreen() {
     <View style={styles.container}>
       <View style={styles.panel}>
         <Text style={styles.title}>Backup & Sincronização</Text>
-        <View style={{ marginBottom: 8 }}><Button title="Exportar (JSON) & Compartilhar" onPress={onExport} /></View>
-        <View style={{ marginBottom: 8 }}><Button title="Importar de arquivo (JSON)" onPress={onImport} /></View>
-        <View style={{ marginBottom: 8 }}><Button title="Enviar backup para Google Drive" onPress={onDriveLoginAndUpload} /></View>
+        <View style={{ marginBottom: 8 }}><PrimaryButton title="Exportar (JSON) & Compartilhar" onPress={onExport} /></View>
+        <View style={{ marginBottom: 8 }}><PrimaryButton title="Importar de arquivo (JSON)" onPress={onImport} /></View>
+        <View style={{ marginBottom: 8 }}><PrimaryButton title="Enviar backup para Google Drive" onPress={onDriveLoginAndUpload} /></View>
         {loading ? <ActivityIndicator /> : <Text style={{ color: '#555', marginTop: 8 }}>{status}</Text>}
         <Text style={{ color: '#777', marginTop: 12 }}>
           Observação: crie um OAuth Client (Expo) e coloque o CLIENT_ID em BackupScreen.js.

--- a/src/screens/CardsScreen.js
+++ b/src/screens/CardsScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, Pressable, Switch } from 'react-native';
+import { View, Text, StyleSheet, Pressable, Switch } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getQuestionsByQuiz, applySrsResult } from '../db';
 import TagChips from '../components/TagChips';
@@ -72,12 +73,12 @@ export default function CardsScreen({ route, navigation }) {
 
         {show ? (
           <View style={styles.row}>
-            <View style={{ flex: 1 }}><Button title="Errei" onPress={async () => { setScore(s => ({ ...s, wrong: s.wrong + 1 })); await applySrsResult(cur.id, false); next(); }} /></View>
+            <View style={{ flex: 1 }}><PrimaryButton title="Errei" onPress={async () => { setScore(s => ({ ...s, wrong: s.wrong + 1 })); await applySrsResult(cur.id, false); next(); }} style={{ flex: 1 }} /></View>
             <View style={{ width: 8 }} />
-            <View style={{ flex: 1 }}><Button title="Acertei" onPress={async () => { setScore(s => ({ ...s, right: s.right + 1 })); await applySrsResult(cur.id, true); next(); }} /></View>
+            <View style={{ flex: 1 }}><PrimaryButton title="Acertei" onPress={async () => { setScore(s => ({ ...s, right: s.right + 1 })); await applySrsResult(cur.id, true); next(); }} style={{ flex: 1 }} /></View>
           </View>
         ) : (
-          <Button title="Mostrar resposta" onPress={() => setShow(true)} />
+          <PrimaryButton title="Mostrar resposta" onPress={() => setShow(true)} />
         )}
 
         <Text style={{ marginTop: 12, color: '#555' }}>{idx + 1} / {cards.length} • Acertos: {score.right}</Text>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, Pressable } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import { getQuizzes, countQuestions } from '../db';
 
 export default function HomeScreen({ navigation }) {
@@ -29,16 +30,16 @@ export default function HomeScreen({ navigation }) {
         <Text style={styles.title}>Bem-vindo 👋</Text>
         <Text style={styles.subtitle}>Monte seus baralhos e comece a estudar</Text>
         <View style={styles.row}>
-          <View style={styles.btn}><Button title="Estudar Hoje" onPress={() => goTab('Estudar')} /></View>
-          <View style={styles.btn}><Button title="Estatísticas" onPress={() => goTab('Estatísticas')} /></View>
-          <View style={styles.btn}><Button title="Backup" onPress={() => goTab('Backup')} /></View>
+          <View style={styles.btn}><PrimaryButton title="Estudar Hoje" onPress={() => goTab('Estudar')} /></View>
+          <View style={styles.btn}><PrimaryButton title="Estatísticas" onPress={() => goTab('Estatísticas')} /></View>
+          <View style={styles.btn}><PrimaryButton title="Backup" onPress={() => goTab('Backup')} /></View>
         </View>
       </View>
 
       <View style={styles.panel}>
         <View style={styles.headerRow}>
           <Text style={styles.titleSmall}>Seus Quizzes</Text>
-          <Button title="Importar" onPress={() => navigation.navigate('Import')} />
+          <PrimaryButton title="Importar" onPress={() => navigation.navigate('Import')} />
         </View>
         {quizzes.length === 0 ? (
           <Text style={{ color: '#666' }}>Crie um quiz ou importe perguntas.</Text>
@@ -50,7 +51,7 @@ export default function HomeScreen({ navigation }) {
         ))}
       </View>
 
-      <View style={styles.fab}><Button title="Novo Quiz" onPress={() => navigation.navigate('QuizEditor')} /></View>
+      <View style={styles.fab}><PrimaryButton title="Novo Quiz" onPress={() => navigation.navigate('QuizEditor')} /></View>
     </View>
   );
 }

--- a/src/screens/ImportScreen.js
+++ b/src/screens/ImportScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import { importText } from '../util/importer';
@@ -35,7 +36,7 @@ export default function ImportScreen({ navigation }) {
     <View style={styles.container}>
       <Text>Selecione um arquivo CSV ou JSON com perguntas e respostas.</Text>
       <View style={{ height: 12 }} />
-      <Button title="Escolher arquivo" onPress={pick} />
+      <PrimaryButton title="Escolher arquivo" onPress={pick} />
       <View style={{ height: 16 }} />
       {loading ? <ActivityIndicator /> : <Text style={{ color: '#555' }}>{status}</Text>}
       <View style={{ height: 12 }} />

--- a/src/screens/LearnScreen.js
+++ b/src/screens/LearnScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, Switch, Pressable } from 'react-native';
+import { View, Text, StyleSheet, Switch, Pressable } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getQuestionsByQuiz, getQuizzes, applySrsResult } from '../db';
 import TagChips from '../components/TagChips';
@@ -98,7 +99,7 @@ export default function LearnScreen({ route, navigation }) {
             <Text style={styles.title}>Sessão concluída</Text>
             <Text>Pontuação: {state.score}/{state.total}</Text>
             <View style={{ height: 12 }} />
-            <Button title="Concluir" onPress={() => navigation.goBack()} />
+            <PrimaryButton title="Concluir" onPress={() => navigation.goBack()} />
           </View>
         </View>
       </SafeAreaView>
@@ -137,7 +138,7 @@ export default function LearnScreen({ route, navigation }) {
               <Text style={{ marginTop: 6, flexWrap: 'wrap' }}>Resposta correta: {String(state.current.answer)}</Text>
               {state.current.explanation ? <Text style={{ marginTop: 6, color: '#333', flexWrap: 'wrap' }}>Explicação: {state.current.explanation}</Text> : null}
               <View style={{ height: 12 }} />
-              <Button title="Próxima" onPress={next} />
+              <PrimaryButton title="Próxima" onPress={next} />
             </View>
           )}
           <Text style={{ marginTop: 10, color: '#555' }}>{state.index + 1} de {state.total}</Text>

--- a/src/screens/QuestionEditorScreen.js
+++ b/src/screens/QuestionEditorScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { View, TextInput, StyleSheet, Text } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import { createQuestion } from '../db';
 
 export default function QuestionEditorScreen({ route, navigation }) {
@@ -24,7 +25,7 @@ export default function QuestionEditorScreen({ route, navigation }) {
       <TextInput style={styles.input} value={explanation} onChangeText={setExplanation} />
       <Text style={styles.label}>Tags (opcional)</Text>
       <TextInput style={styles.input} value={tags} onChangeText={setTags} />
-      <Button title="Salvar" onPress={save} disabled={!text.trim() || !answer.trim()} />
+      <PrimaryButton title="Salvar" onPress={save} disabled={!text.trim() || !answer.trim()} />
     </View>
   );
 }

--- a/src/screens/QuestionListScreen.js
+++ b/src/screens/QuestionListScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getQuestionsByQuiz } from '../db';
 
@@ -17,7 +18,7 @@ export default function QuestionListScreen({ route, navigation }) {
     <SafeAreaView style={styles.sa} edges={['bottom']}>
       <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
         <View style={styles.actions}>
-          <Button title="Adicionar" onPress={() => navigation.navigate('QuestionEditor', { quizId })} />
+          <PrimaryButton title="Adicionar" onPress={() => navigation.navigate('QuestionEditor', { quizId })} />
         </View>
 
         <ScrollView style={styles.list} contentContainerStyle={{ paddingBottom: 16 }}>
@@ -33,11 +34,11 @@ export default function QuestionListScreen({ route, navigation }) {
 
         <View style={[styles.footer, { paddingBottom: Math.max(insets.bottom, 8) }]}>
           <View style={{ flex: 1 }}>
-            <Button title="Cartões" onPress={() => navigation.navigate('Cards', { quizId })} />
+            <PrimaryButton title="Cartões" onPress={() => navigation.navigate('Cards', { quizId })} />
           </View>
           <View style={{ width: 8 }} />
           <View style={{ flex: 1 }}>
-            <Button title="Aprender" onPress={() => navigation.navigate('Learn', { quizId })} />
+            <PrimaryButton title="Aprender" onPress={() => navigation.navigate('Learn', { quizId })} />
           </View>
         </View>
       </View>

--- a/src/screens/QuizEditorScreen.js
+++ b/src/screens/QuizEditorScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { View, TextInput, StyleSheet, Text } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import { createQuiz } from '../db';
 
 export default function QuizEditorScreen({ navigation }) {
@@ -14,7 +15,7 @@ export default function QuizEditorScreen({ navigation }) {
       <TextInput style={styles.input} value={title} onChangeText={setTitle} />
       <Text style={styles.label}>Descrição (opcional)</Text>
       <TextInput style={[styles.input, { height: 100 }]} multiline value={desc} onChangeText={setDesc} />
-      <Button title="Salvar" onPress={save} disabled={!title.trim()} />
+      <PrimaryButton title="Salvar" onPress={save} disabled={!title.trim()} />
     </View>
   );
 }

--- a/src/screens/StudyTodayScreen.js
+++ b/src/screens/StudyTodayScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet, TextInput } from 'react-native';
+import { View, Text, StyleSheet, TextInput } from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
 import { getQuizzes, getQuestionsByQuiz } from '../db';
 import TagChips from '../components/TagChips';
 import { distinctTagsFromQuestions, tagCounts, parseTags } from '../util/tags';
@@ -68,7 +69,7 @@ export default function StudyTodayScreen({ navigation }) {
         </View>
         <Text style={{ marginTop: 8, color: '#555' }}>Vencidos no filtro: {dueTotal}</Text>
         <View style={{ height: 12 }} />
-        <Button title="Iniciar sessão (Aprender)" onPress={startLearn} />
+        <PrimaryButton title="Iniciar sessão (Aprender)" onPress={startLearn} />
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- apply navigation theme and status bar styling for cohesive look
- add reusable PrimaryButton and replace default buttons across screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a66f0f5604832a99ed89ca07756167