### PR TITLE
Fix duplicate StatusBar import causing build error

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,7 +7,6 @@ import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { StatusBar } from 'expo-status-bar';
 
 import { navTheme } from './src/theme';
 


### PR DESCRIPTION
## Summary
- remove duplicate StatusBar import in App.js to avoid redeclaration errors

## Testing
- `npm run web` *(fails: TypeError fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6728d9ae4832a878a553212c2dc10