### PR TITLE
Add quiz deletion button and SafeAreaView wrapper

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,12 +2,11 @@ import 'react-native-gesture-handler';
 import React, { useEffect } from 'react';
 import { useColorScheme } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { StatusBar } from 'expo-status-bar';
 
 import { navTheme } from './src/theme';
 
@@ -71,18 +70,20 @@ export default function App() {
   useEffect(() => { initDb(); }, []);
   return (
     <SafeAreaProvider>
-      <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
-        <Stack.Navigator>
-          <Stack.Screen name="Tabs" component={Tabs} options={{ headerShown: false }} />
-          <Stack.Screen name="QuizEditor" component={QuizEditorScreen} options={{ title: 'Novo Quiz' }} />
-          <Stack.Screen name="QuestionList" component={QuestionListScreen} options={{ title: 'Perguntas' }} />
-          <Stack.Screen name="QuestionEditor" component={QuestionEditorScreen} options={{ title: 'Nova Pergunta' }} />
-          <Stack.Screen name="Import" component={ImportScreen} options={{ title: 'Importar' }} />
-          <Stack.Screen name="Cards" component={CardsScreen} options={{ title: 'Cartões' }} />
-          <Stack.Screen name="Learn" component={LearnScreen} options={{ title: 'Aprender' }} />
-        </Stack.Navigator>
-      </NavigationContainer>
+      <SafeAreaView style={{ flex: 1 }}>
+        <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
+          <Stack.Navigator>
+            <Stack.Screen name="Tabs" component={Tabs} options={{ headerShown: false }} />
+            <Stack.Screen name="QuizEditor" component={QuizEditorScreen} options={{ title: 'Novo Quiz' }} />
+            <Stack.Screen name="QuestionList" component={QuestionListScreen} options={{ title: 'Perguntas' }} />
+            <Stack.Screen name="QuestionEditor" component={QuestionEditorScreen} options={{ title: 'Nova Pergunta' }} />
+            <Stack.Screen name="Import" component={ImportScreen} options={{ title: 'Importar' }} />
+            <Stack.Screen name="Cards" component={CardsScreen} options={{ title: 'Cartões' }} />
+            <Stack.Screen name="Learn" component={LearnScreen} options={{ title: 'Aprender' }} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </SafeAreaView>
     </SafeAreaProvider>
   );
 }

--- a/src/db.js
+++ b/src/db.js
@@ -57,6 +57,10 @@ export async function createQuiz(title, description = '') {
   const res = await db.runAsync('INSERT INTO quiz(title, description) VALUES (?,?)', [title, description]);
   return res.lastInsertRowId;
 }
+export async function deleteQuiz(id) {
+  const db = await getDb();
+  await db.runAsync('DELETE FROM quiz WHERE id = ?', [id]);
+}
 export async function countQuestions(quizId) {
   const db = await getDb();
   const row = await db.getFirstAsync('SELECT COUNT(*) as c FROM question WHERE quizId = ?', [quizId]);

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { View, Text, Button, StyleSheet, Pressable, FlatList } from 'react-native';
+import { View, Text, Button, StyleSheet, Pressable, FlatList, Alert } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { getQuizzes, countQuestions } from '../db';
+import { getQuizzes, countQuestions, deleteQuiz } from '../db';
 
 export default function HomeScreen({ navigation }) {
   const [quizzes, setQuizzes] = useState([]);
@@ -15,6 +15,13 @@ export default function HomeScreen({ navigation }) {
     setQuizzes(withCounts);
   };
 
+  const handleDelete = (id) => {
+    Alert.alert('Excluir', 'Deseja excluir este quiz?', [
+      { text: 'Cancelar', style: 'cancel' },
+      { text: 'Excluir', style: 'destructive', onPress: async () => { await deleteQuiz(id); load(); } }
+    ]);
+  };
+
   useEffect(() => {
     const unsub = navigation.addListener('focus', load);
     return unsub;
@@ -26,18 +33,23 @@ export default function HomeScreen({ navigation }) {
   };
 
   const renderItem = ({ item }) => (
-    <Pressable
-      key={item.id}
-      onPress={() => navigation.navigate('QuestionList', { quizId: item.id, title: item.title })}
-      style={({ pressed }) => [styles.item, pressed && { opacity: 0.85 }]}
-      android_ripple={{ color: '#e9e9e9' }}
-      hitSlop={8}
-      accessibilityRole="button"
-      accessibilityLabel={`Abrir quiz ${item.title}`}
-    >
-      <Text style={styles.itemTitle}>{item.title}</Text>
-      <Text style={styles.itemDesc}>{item.total} cartões</Text>
-    </Pressable>
+    <View style={styles.itemRow}>
+      <Pressable
+        key={item.id}
+        onPress={() => navigation.navigate('QuestionList', { quizId: item.id, title: item.title })}
+        style={({ pressed }) => [styles.item, pressed && { opacity: 0.85 }]}
+        android_ripple={{ color: '#e9e9e9' }}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`Abrir quiz ${item.title}`}
+      >
+        <Text style={styles.itemTitle}>{item.title}</Text>
+        <Text style={styles.itemDesc}>{item.total} cartões</Text>
+      </Pressable>
+      <View style={styles.delBtn}>
+        <Button title="Excluir" color="#b00020" onPress={() => handleDelete(item.id)} />
+      </View>
+    </View>
   );
 
   const listHeader = useMemo(() => (
@@ -86,7 +98,9 @@ const styles = StyleSheet.create({
   titleSmall: { fontSize: 18, fontWeight: '700', marginTop: 12 },
   subtitle: { color: '#555', marginTop: 4 },
   headerRow: { marginTop: 8, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  item: { padding: 12, backgroundColor: '#fff', borderRadius: 12, borderWidth: 1, borderColor: '#eee' },
+  itemRow: { flexDirection: 'row', alignItems: 'center' },
+  item: { flex: 1, padding: 12, backgroundColor: '#fff', borderRadius: 12, borderWidth: 1, borderColor: '#eee' },
+  delBtn: { marginLeft: 8 },
   itemTitle: { fontSize: 16, fontWeight: '600', flexWrap: 'wrap' },
   itemDesc: { color: '#666', marginTop: 2 },
   empty: { color: '#666', paddingHorizontal: 16 },


### PR DESCRIPTION
## Summary
- wrap app content in SafeAreaView so screens respect Android safe area insets
- allow deleting quizzes from the home screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run web` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6728d9ae4832a878a553212c2dc10